### PR TITLE
nvim: remove nvim-treesitter

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -96,8 +96,6 @@ require("lazy").setup({
     },
     -- 'nvim-telescope/telescope-ui-select.nvim',
     "stevearc/dressing.nvim",
-    -- tree-sitter
-    { "nvim-treesitter/nvim-treesitter", build = ":TSUpdate" },
     -- lsp
     { "SmiteshP/nvim-navic" },
     {
@@ -584,29 +582,6 @@ vim.keymap.set("n", "<leader>ft", require("telescope-tabs").list_tabs, {})
 -- language specific
 
 require("satysfi-nvim").setup()
-
--- treesitter ----------------------
-
-require("nvim-treesitter.configs").setup({
-    -- ensure_installed = {
-    --   "satysfi",
-    -- },
-    highlight = {
-        enable = true,
-    },
-    incremental_selection = {
-        enable = true,
-        keymaps = {
-            init_selection = "gs",
-            node_incremental = "gs",
-            scope_incremental = "gS",
-            node_decremental = "gm",
-        },
-    },
-    indent = {
-        enable = true,
-    },
-})
 
 -- language specific settings
 

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -21,7 +21,6 @@
   "nvim-cmp": { "branch": "main", "commit": "29fb4854573355792df9e156cb779f0d31308796" },
   "nvim-navbuddy": { "branch": "master", "commit": "f22bac988f2dd073601d75ba39ea5636ab6e38cb" },
   "nvim-navic": { "branch": "master", "commit": "8649f694d3e76ee10c19255dece6411c29206a54" },
-  "nvim-treesitter": { "branch": "master", "commit": "39016abc99853c3e9d70f1bec7e2fa661b9a81bf" },
   "nvim-web-devicons": { "branch": "master", "commit": "19d257cf889f79f4022163c3fbb5e08639077bd8" },
   "oil.nvim": { "branch": "master", "commit": "cca1631d5ea450c09ba72f3951a9e28105a3632c" },
   "plenary.nvim": { "branch": "master", "commit": "2d9b06177a975543726ce5c73fca176cedbffe9d" },


### PR DESCRIPTION
nvim-treesitter をやめた

トラブルが多い印象、かつ設定管理の手間も大きい、 archive されてしまったというもろもろの事情を鑑みて
Neovim のバージョンアップなどにともなっていちいちトラブルが発生しがちで、対応に疲れてしまったというのが正直なところ
Neovim 0.12 に上げた際も、 markdown の highlight でエラーを吐くようになり、 nvim-treesitter を削除したら解消した

とはいえ、 markdown の入れ子 (injection) の highlight が効かなくなるのはちょっとさみしい
また気が向いたら検討する、以下は使いたくなったときのためのメモ

### セットアップ

nvim-treesitter の commit は以下で確認
4916d6592ede8c07973490d9322f187e07dfefac

`:TSInstall rust` としようとしたら、 tree-sitter コマンドがないと怒られた
tree-sitter-cli に依存するようになったらしい
https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md

cargo があれば以下のコマンドで入る

```
cargo install --locked tree-sitter-cli
```

数分かかるので、 cargo の setup も込みで、 setup 速度が欲しい環境ではあまりやりたくないかな、というのが正直なところ...
どうしたものか

### 蛇足

65c7fc2168d7f01ddbbf24631c153a203f05d882 で lazy.nvim のバージョンを上げたのは、なぜか main の最新 commit をもってこれないバグがあったため
いちおう、 nvim-treesitter を最新にすれば機能はしていそうな雰囲気だった