### PR TITLE
bootstrap: Handling zsh login shell

### DIFF
--- a/.config/profile.d/00-init.sh
+++ b/.config/profile.d/00-init.sh
@@ -12,7 +12,11 @@ add_path() {
 }
 
 # mise
-eval "$(~/.local/bin/mise activate bash)"
+if [ -n "${ZSH_VERSION:-}" ]; then
+    eval "$(~/.local/bin/mise activate zsh)"
+else
+    eval "$(~/.local/bin/mise activate bash)"
+fi
 
 # $HOME/bin (highest priority)
 add_path "$HOME/bin"

--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -3,14 +3,21 @@ set -euo pipefail
 
 echo "==> Bootstrap: setting up mise environment"
 
-# Configure bashrc to source scripts in ~/.config/profile.d
-BASHRC="$HOME/.bashrc"
+# Determine the login shell and configuration file (default: bash)
+SHELL_NAME="bash"
+SHELL_RC="$HOME/.bashrc"
+if [[ "${SHELL:-}" == *zsh ]]; then
+    SHELL_NAME="zsh"
+    SHELL_RC="$HOME/.zshrc"
+fi
+
+# Configure shell RC to source scripts in ~/.config/profile.d
 MARKER="# >>> sankantsu/dotfiles: profile.d >>>"
-if grep -qF "$MARKER" "$BASHRC"; then
-    echo "==> profile.d sourcing already configured in $BASHRC, skipping"
+if [ -f "$SHELL_RC" ] && grep -qF "$MARKER" "$SHELL_RC"; then
+    echo "==> profile.d sourcing already configured in $SHELL_RC, skipping"
 else
-    echo "==> Configuring profile.d sourcing in $BASHRC"
-    cat >> "$BASHRC" <<'EOF'
+    echo "==> Configuring profile.d sourcing in $SHELL_RC"
+    cat >> "$SHELL_RC" <<'EOF'
 
 # >>> sankantsu/dotfiles: profile.d >>>
 if [ -d "$HOME/.config/profile.d" ]; then
@@ -46,4 +53,4 @@ mise run setup
 echo "==> Bootstrap complete!"
 echo ""
 echo "Run the following to apply shell changes to your current session:"
-echo "source ~/.bashrc"
+echo "source $SHELL_RC"


### PR DESCRIPTION
closes #41 

bootstrap 時 (bash 実行) は `$SHELL` で、 profile.d ロード時 (使用中の (login) shell で実行) は `$ZSH_VERSION` で判定を行う。